### PR TITLE
Remove references to Aero

### DIFF
--- a/src/mach/core.cljs
+++ b/src/mach/core.cljs
@@ -8,8 +8,6 @@
    [cljs.reader :as reader]
    [cljs.js :as cljs]
    [lumo.repl :as repl]
-   [aero.core :as aero]
-   aero.aws ; aero aws credentials reader
    [clojure.walk :refer [postwalk]]
    [clojure.string :as str]))
 


### PR DESCRIPTION
This addresses #8.

I suspect that leaving these references in Mach was just an oversight after removing the vendored `aero.core` and `aero.aws` namespaces. As far as I could tell the Aero reader was not being used by Mach.

The recent change broke my install from NPM when I upgraded.