### PR TITLE
Use bundled lumo

### DIFF
--- a/bin/mach
+++ b/bin/mach
@@ -11,4 +11,4 @@ else
     ARGS=main
 fi
 
-NODE_PATH="${MACH_HOME}/node_modules" lumo -c ${MACH_HOME}/src:${MACH_CLASSPATH} ${MACH_HOME}/src/mach/core.cljs $ARGS
+NODE_PATH="${MACH_HOME}/node_modules" ${MACH_HOME}/node_modules/.bin/lumo -c ${MACH_HOME}/src:${MACH_CLASSPATH} ${MACH_HOME}/src/mach/core.cljs $ARGS


### PR DESCRIPTION
This makes Mach use it's npm-dependency version of lumo. This makes mach to depend on a specific version of lumo that it is compatible with. This is opposed to currently, where the users globally installed lumo is used instead.