### PR TITLE
Add support for dynamically matching targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
   },
   "homepage": "https://github.com/juxt/mach#README.md",
   "dependencies": {
-      "ini": "^1.3.4",
-      "lumo-cljs": "1.4.1",
-      "toposort": "^1.0.0",
-      "tmp": "0.0.31",
-      "yargs": "^8.0.1"
+    "ini": "^1.3.4",
+    "lumo-cljs": "1.4.1",
+    "micromatch": "^2.3.11",
+    "tmp": "0.0.31",
+    "toposort": "^1.0.0",
+    "yargs": "^8.0.1"
   }
 }


### PR DESCRIPTION
There is a basis protocol (Target) which exposes match? for whether or
not a target matches. A sequential search is then performed over all
targets for each input target.

Example usage of this feature:

```
;; Machfile.edn
{#mach/glob "*.md" {product "somefile"
		    produce (str "# A title")}}

$ mach hello.md
Writing somefile
```

Further functionality that is necessary to make this feature useful is
the exposure of the match ctx (already assoced onto the target when it
matches) so that code can refer to the full path. To extend the example
above, the future feature should allow the product to be set based on
the matching input.

I haven't thoroughly tested this, so a second pair of eyes over this
would be good.