### PR TITLE
Fix dependency execution order

### DIFF
--- a/src/mach/core.cljs
+++ b/src/mach/core.cljs
@@ -280,15 +280,15 @@
         ;; Call update!
         (when (or (true? novelty)
                   (and (seq? novelty) (not-empty novelty)))
-          (update! machfile (assoc target 'novelty `(quote ~novelty)))))
+          (<! (update! machfile (assoc target 'novelty `(quote ~novelty))))))
 
       ;; Target is an expr or there is no novelty, press on:
-      (update! machfile target))))
+      (<! (update! machfile target)))))
 
 ;; Run the update (or produce) and print, no deps
 (defmethod apply-verb 'update [machfile [target-name target] verg]
   (go
-    (update! machfile target)))
+    (<! (update! machfile target))))
 
 ;; Print the produce
 (defmethod apply-verb 'print [machfile [target-name target] verb]


### PR DESCRIPTION
this makes the next dependency wait on the completion of the current update.
fixes #41 