### PR TITLE
fix #ref reader tag

### DIFF
--- a/src/mach/core.cljs
+++ b/src/mach/core.cljs
@@ -44,7 +44,7 @@
 (defn ^:private read-reference [path]
   (->Reference path))
 
-(reader/register-tag-parser! "ref" read-reference)
+(reader/register-tag-parser! 'ref read-reference)
 
 (def fs (nodejs/require "fs"))
 (def child_process (nodejs/require "child_process"))


### PR DESCRIPTION
Without this fix, #ref breaks with the error

```
evalmachine.<anonymous>:98
throw ex;
^
Error: No reader function for tag ref.
    at new cljs.core.ExceptionInfo (<embedded>:1920:47)
    at Function.cljs.core.ex_info.cljs$core$IFn$_invoke$arity$3 (<embedded>:1923:72)
    at Function.cljs.core.ex_info.cljs$core$IFn$_invoke$arity$2 (<embedded>:1922:449)
    at Function.cljs.tools.reader.impl.errors.throw_ex.cljs$core$IFn$_invoke$arity$variadic (evalmachine.<anonymous>:53:25)
    at Function.cljs.tools.reader.impl.errors.reader_error.cljs$core$IFn$_invoke$arity$variadic (evalmachine.<anonymous>:91:47)
    at Object.cljs$tools$reader$impl$errors$throw_unknown_reader_tag [as throw_unknown_reader_tag] (evalmachine.<anonymous>:336:51)
    at Object.cljs$tools$reader$edn$read_tagged [as read_tagged] (evalmachine.<anonymous>:783:38)
    at evalmachine.<anonymous>:118:191
    at cljs$tools$reader$edn$read_dispatch (evalmachine.<anonymous>:119:3)
    at Object.cljs$tools$reader$edn$read_delimited [as read_delimited] (evalmachine.<anonymous>:320:106)
```