### PR TITLE
mach test: use mach classpath so andare is added

### DIFF
--- a/Machfile.edn
+++ b/Machfile.edn
@@ -1,1 +1,2 @@
-{test #$ ["lumo" "-c" "src:test" "-m" "mach.lumo-test"]}
+{test #$ ["lumo" "-c" "src:test" "-c" (clojure.string/join ":" (lumo.classpath/classpath))
+          "-m" "mach.lumo-test"]}


### PR DESCRIPTION
Running `mach test` was failing with errors like `No such namespace: cljs.core.async`. That's because andare's jar was not being added to the classpath as it's done in bin/mach. We can just take lumo's classpath that already includes the jar, because we are in the context of the lumo process started from the `mach test` command

As an alternative, my first approach was to simply add `-c ${MACH_HOME}/lib/andare-0.7.0.jar` in the test command, following what's done in `bin/mach`. Then I thought this approach would be more generic, but I'm not sure what's better: the downside of this approach is that it adds more stuff than needed (currently: `.` and `./src` apart from andare's jar)