### PR TITLE
Use proper link to clj-boot in README file

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,7 +31,7 @@ $ sudo npm install -g @juxt/mach
 ....
 
 Mach uses `boot` to resolve dependencies mentioned in the Machfile, so
-you might want to install [`boot-clj`](https://github.com/boot-clj/boot)
+you might want to install https://github.com/boot-clj/boot[boot-clj]
 while your at it.
 
 Mach ships with https://github.com/anmonteiro/lumo[Lumo] 1.7.0.


### PR DESCRIPTION
This PR make the correction to the link to`boot-clj`