### PR TITLE
Check for existence of Machfile.edn

### DIFF
--- a/bin/mach
+++ b/bin/mach
@@ -3,7 +3,12 @@
 # Mach
 # Copyright © 2016-2017, JUXT LTD.
 
-mkdir -p .mach
+if [ -e "Machfile.edn" ]; then
+    mkdir -p .mach
+else
+    echo "Machfile.edn could not be found"
+    exit 1
+fi
 export MACH_HOME=${MACH_HOME:-$(npm -g root)/\@juxt/mach}
 
 if [ $# -gt 0 ]; then


### PR DESCRIPTION
Adds a check to the shell script that invokes `mach` for the existence of a `Machfile.edn`, and exits with an error message if that's not the case. This avoids the error that occurs when `mach` is invoked accidentally from somewhere where a `Machfile` isn't available, avoiding the creation of an unnecessary `.mach/` directory.

Fixes #58

I had added a `(ensure-machfile-exists)` function to `mach.core` before realising that the wrapper script might be a better place to do this check. If you'd prefer to handle this some other way, I'm happy to make whatever changes you'd like.